### PR TITLE
ac-refactor-contact-info

### DIFF
--- a/routes/generalUsers.js
+++ b/routes/generalUsers.js
@@ -29,13 +29,13 @@ router.get('/', async (req, res) => {
 // add a general user
 router.post('/', async (req, res) => {
   try {
-    const { firstName, lastName, phoneNumber, email, title } = req.body;
+    const { firstName, lastName, phoneNumber, email } = req.body;
     isNumeric(phoneNumber, 'Invalid Phone Number');
     const newUser = await pool.query(
-      `INSERT INTO general_user (first_name, last_name, phone_number, email, title)
-      VALUES ($1, $2, $3, $4, $5)
+      `INSERT INTO general_user (first_name, last_name, phone_number, email)
+      VALUES ($1, $2, $3, $4)
       RETURNING *;`,
-      [firstName, lastName, phoneNumber, email, title],
+      [firstName, lastName, phoneNumber, email],
     );
     res.status(200).send(keysToCamel(newUser.rows[0]));
   } catch (err) {
@@ -48,15 +48,15 @@ router.put('/:userId', async (req, res) => {
   try {
     const { userId } = req.params;
     isNumeric(userId, 'User Id must be a Number');
-    const { firstName, lastName, phoneNumber, email, title } = req.body;
+    const { firstName, lastName, phoneNumber, email } = req.body;
     isNumeric(phoneNumber, 'Invalid Phone Number');
     const updatedUser = await pool.query(
       `UPDATE general_user
       SET first_name = $1, last_name = $2,
-          phone_number = $3, email = $4, title = $5
-      WHERE user_id = $6
+          phone_number = $3, email = $4
+      WHERE user_id = $5
       RETURNING *;`,
-      [firstName, lastName, phoneNumber, email, title, userId],
+      [firstName, lastName, phoneNumber, email, userId],
     );
     res.status(200).send(keysToCamel(updatedUser.rows[0]));
   } catch (err) {

--- a/server/database.sql
+++ b/server/database.sql
@@ -18,7 +18,6 @@ CREATE TABLE general_user (
   last_name VARCHAR(255) NOT NULL,
   phone_number VARCHAR(15) NOT NULL,
   email VARCHAR(255) NOT NULL,
-  title VARCHAR(255)
 );
 
 DROP TABLE tlp_user CASCADE;
@@ -63,10 +62,18 @@ CREATE TABLE site (
   address_city VARCHAR(255) NOT NULL,
   address_zip VARCHAR(5) NOT NULL,
   area_id INT REFERENCES area(area_id) ON DELETE SET NULL NOT NULL,
-  primary_contact_id INT REFERENCES general_user(user_id) NOT NULL,
-  second_contact_id INT REFERENCES general_user(user_id),
   active BOOLEAN NOT NULL,
-  notes VARCHAR(255)
+  notes VARCHAR(255),
+  primary_contact_first_name VARCHAR(255) NOT NULL,
+  primary_contact_last_name VARCHAR(255) NOT NULL,
+  primary_contact_title VARCHAR(255),
+  primary_contnact_email VARCHAR(255) NOT NULL,
+  primary_contact_phone_number VARCHAR(15) NOT NULL,
+  second_contact_first_name VARCHAR(255),
+  second_contact_last_name VARCHAR(255),
+  second_contact_title VARCHAR(255),
+  second_contact_email VARCHAR(255),
+  second_contact_phone_number VARCHAR(15)
 );
 
 DROP TABLE student_group CASCADE;


### PR DESCRIPTION
Currently, our DB stores site primary/secondary contacts as a reference to the `general_user`. However, there are some issues with doing this (mainly that we don't want any change we make to a primary/secondary user to impact the admins/MTs). Please make the following changes.

Schema:
- Remove primary_contact_id and secondary_contact_id from the `site` table.
- Add primary_contact_name, primary_contact_title, primary_contact_email, and primary_contact_phone as required fields within the `site` table.
- Add secondary_contact_name, secondary_contact_title, secondary_contact_email, and secondary_contact_phone as optional fields within the `site` table.

Routes:
- Update `sites.js` incorporate the primary/secondary contact info. You will need to change the `getSites` function, the POST route, and the PUT route.

closes #49